### PR TITLE
Add support for `move-focus-or-tab` when navigating left / right

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ keys = {
 },
 ```
 
+### Using Zellij's MoveFocusOrTab Action
+
+By default Zellij's `move-focus` action is used when navigating. If you want to use `move-focus-or-tab` instead, in order to navigate to the next / previous tab when focus is on the edge of the screen, then set the following:
+
+```vim
+let g:zellij_navigator_nav_move_focus_or_tab = 1
+```
+
 ### More Vim / Zellij Integration
 
 Even without this plugin, you can control Zellij by calling the Zellij CLI from within Vim. For example, here's a Vim autocommand which names the current Zellij tab after Vim's current working directory (an excerpt from [my dotfiles](https://github.com/fresh2dev/dotfiles)):

--- a/autoload/zellij_navigator.vim
+++ b/autoload/zellij_navigator.vim
@@ -1,28 +1,30 @@
-function! s:zellij_nav(short_direction, direction)
+function! s:zellij_nav(short_direction, direction, move_focus_or_tab=0)
     " get window ID, try switching windows, and get ID again to see if it worked
     let cur_winnr = winnr()
     execute "wincmd " . a:short_direction
 
     " if the window ID didn't change, then we didn't switch
     if cur_winnr == winnr()
-        call system("zellij action move-focus " . a:direction)
+        " use 'move-focus-or-tab' if move_focus_or_tab is true
+        let l:action = a:move_focus_or_tab ? "move-focus-or-tab" : "move-focus"
+        call system("zellij action " . l:action . " " . a:direction)
     endif
 endfunction
 
 function! zellij_navigator#ZellijNavigateUp()
-    call s:zellij_nav("k", "up")
+    call s:zellij_nav("k", "up", 0)
 endfunction
 
 function! zellij_navigator#ZellijNavigateDown()
-    call s:zellij_nav("j", "down")
+    call s:zellij_nav("j", "down", 0)
 endfunction
 
 function! zellij_navigator#ZellijNavigateRight()
-    call s:zellij_nav("l", "right")
+    call s:zellij_nav("l", "right", get(g:, 'zellij_navigator_nav_move_focus_or_tab', 0))
 endfunction
 
 function! zellij_navigator#ZellijNavigateLeft()
-    call s:zellij_nav("h", "left")
+    call s:zellij_nav("h", "left", get(g:, 'zellij_navigator_nav_move_focus_or_tab', 0))
 endfunction
 
 function! zellij_navigator#ZellijLock()


### PR DESCRIPTION
The `move-focus-or-tab` action in Zellij moves focus left or right, or moves to the previous or next tab if focus is on the edge of the screen.

Setting `g:zelli_navigator_nav_move_focus_or_tab` to `1` enables `move-focus-or-tab`. The `move-focus` action remains the default.